### PR TITLE
chapter 6: fix typo

### DIFF
--- a/book/04-git-server/sections/smart-http.asc
+++ b/book/04-git-server/sections/smart-http.asc
@@ -91,7 +91,7 @@ $ htdigest -c /opt/git/.htpasswd "Git Access" schacon
 //////////////////////////
 There are tons of ways to have Apache authenticate users, you'll have to choose and implement one of them. This is just the simplest example we could come up with. You'll also almost certainly want to set this up over SSL so all this data is encrypted.
 //////////////////////////
-아파치에는 사용자 인증방법이 많다. 그 중 하나를 골라 사용해야 하는데 위에 설명한 방법이 가장 간단한 방법의 하나다. 이 방법을 이용할 때는 대부분 SSL을 이용해 통신한다.
+아파치에는 사용자 인증방법이 많다. 그중 하나를 골라 사용해야 하는데 위에 설명한 방법이 가장 간단한 방법의 하나다. 이 방법을 이용할 때는 대부분 SSL을 이용해 통신한다.
 
 //////////////////////////
 We don't want to go too far down the rabbit hole of Apache configuration specifics, since you could well be using a different server or have different authenication needs. The idea is that Git comes with a CGI called `git http-backend` that when invoked will do all the negotiation to send and receive data over HTTP. It does not implement any authentication itself, but that can easily be controlled at the layer of the web server that invokes it. You can do this with nearly any CGI-capable web server, so go with the one that you know best.


### PR DESCRIPTION
우리말 배움터의 설명입니다.

> '범위가 정해진 여럿 가운데'의 뜻으로 쓰는 '그중'은 합성어로 보아 붙여
씁니다. 그러나 '그 스님'의 뜻이라면 '그 중'으로 띄어 씁니다.